### PR TITLE
chore: update to Go 1.26 and mittwald golangci-lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,17 +6,14 @@ jobs:
   build:
     name: Run tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.14', '1.13' ]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version: '1.26'
 
       - name: Run unit tests
         run: go test ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          version: v1.27
-          args: --config=build/ci/.golangci.yml
+          go-version: '1.26'
+      - name: golangci-lint
+        run: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 *.iml
 out
 gen
+
+# Claude Code
+.claude

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+CURDIR = $(shell pwd)
+
+.PHONY: test lint lintci
+
+all: test lint
+
+test:
+	go test -count=1 -failfast -v ./...
+
+lint:
+	go mod tidy
+	docker run --rm \
+		-v $(shell go env GOPATH):/go \
+		-v $(CURDIR):/app -w /app \
+		-e GOLANGCI_ADDITIONAL_YML=/app/build/ci/.golangci.yml \
+		quay.io/mittwald/golangci-lint:0.1.2 \
+			golangci-lint run -v --fix ./...

--- a/build/ci/.golangci.yml
+++ b/build/ci/.golangci.yml
@@ -1,102 +1,194 @@
-linters-settings:
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 100
-    statements: 50
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - wrapperFunc
-  gocyclo:
-    min-complexity: 15
-  golint:
-    min-confidence: 0
-  gomnd:
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: argument,case,condition,return
-  govet:
-    check-shadowing: true
-  lll:
-    line-length: 160
-  maligned:
-    suggest-new: true
-  misspell:
-    locale: US
-  nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
-
+version: "2"
+run:
+  build-tags:
+    - codeanalysis
+  tests: false
+  relative-path-mode: gomod
 linters:
-  disable-all: true
+  default: none
   enable:
+    - asasalint
+    - asciicheck
+    - bidichk
     - bodyclose
-    - deadcode
-    - depguard
+    - canonicalheader
+    - containedctx
+    - contextcheck
+    - copyloopvar
     - dogsled
     - dupl
+    - dupword
+    - durationcheck
     - errcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - exptostd
+    - forcetypeassert
     - funlen
-    - gochecknoinits
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - gocognit
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-    - golint
-    - gomnd
+    - gomoddirectives
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
+    - inamedparam
     - ineffassign
-    - interfacer
+    - interfacebloat
+    - intrange
+    - iotamixing
     - lll
+    - makezero
+    - mirror
     - misspell
-    - nakedret
+    - musttag
+    - nestif
+    - nilerr
+    - nilnesserr
+    - nilnil
+    - noctx
     - nolintlint
+    - nosprintfhostport
+    - prealloc
+    - predeclared
+    - promlinter
+    - reassign
+    - recvcheck
+    - revive
     - rowserrcheck
-    - scopelint
+    - sloglint
+    - spancheck
+    - sqlclosecheck
     - staticcheck
-    - structcheck
-    - stylecheck
-    - typecheck
+    - tagliatelle
+    - testableexamples
+    - testifylint
+    - thelper
+    - tparallel
     - unconvert
-    - unparam
     - unused
-    - varcheck
+    - usestdlibvars
+    - usetesting
+    - wastedassign
+  disable:
+    - arangolint
+    - cyclop
+    - decorder
+    - depguard
+    - embeddedstructfieldcheck
+    - err113
+    - exhaustive
+    - exhaustruct
+    - forbidigo
+    - funcorder
+    - ginkgolinter
+    - gochecknoglobals
+    - gochecknoinits
+    - godoclint
+    - godot
+    - godox
+    - goheader
+    - gomodguard
+    - gosmopolitan
+    - grouper
+    - importas
+    - ireturn
+    - loggercheck
+    - maintidx
+    - mnd
+    - nlreturn
+    - noinlineerr
+    - nonamedreturns
+    - paralleltest
+    - protogetter
+    - tagalign
+    - testpackage
+    - unparam
+    - unqueryvet
+    - varnamelen
     - whitespace
-    - goerr113
-
+    - wrapcheck
+    - wsl
+    - wsl_v5
+    - zerologlint
+  settings:
+    dupl:
+      threshold: 100
+    errorlint:
+      errorf: false
+    funlen:
+      lines: 100
+      statements: 60
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - ifElseChain
+        - commentFormatting
+    gocyclo:
+      min-complexity: 20
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 180
+    misspell:
+      locale: US
+    revive:
+      confidence: 0
+      severity: error
+    staticcheck:
+      checks:
+        - "all"
+        - # Omit embedded fields from selector expression.
+        - "-QF1008"
+    testifylint:
+      disable:
+        - equal-values
+        - len
+    nolintlint:
+      allow-unused: false
+    spancheck:
+      extra-start-span-signatures:
+        - "tracing.StartSpanFromContext:opentelemetry"
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - lll
+        source: '^//go:generate '
+      - linters:
+          - staticcheck
+        text: 'SA1019: package github.com/golang/protobuf/proto is deprecated:'
+    paths:
+      - .*_?generated\.go
+      - tests?/
+      - pkg/pb/
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gomnd
-
-run:
-  skip-dirs:
-    - examples/
-  skip-files:
-    - .*_test\.go
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.27.x # use the fixed version to not introduce new linters unexpectedly
+  max-same-issues: 100
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - .*_?generated\.go
+      - tests?/
+      - pkg/pb/
+      - third_party$
+      - builtin$
+      - examples$

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,14 @@ module github.com/hermsi1337/go-magento2
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect
 	gopkg.in/resty.v1 v1.12.0
 )
 
-go 1.14
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+go 1.26

--- a/go.sum
+++ b/go.sum
@@ -1,17 +1,9 @@
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -28,6 +20,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/resty.v1 v1.12.0 h1:CuXP0Pjfw9rOuY6EP+UvtNvt5DSqHpIxILZKT/quCZI=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
- Upgrade Go version from 1.14 to 1.26
- Replace golangci-lint-action with mittwald/golangci-lint Docker image (0.1.2)
- Replace old golangci-lint v1 config with mittwald v2 config
- Add Makefile with lint, lintci and test targets
- Update GitHub Actions to v4/v5
- Remove build matrix in favor of single Go version
- Add .claude to .gitignore